### PR TITLE
Update wifi.cfg

### DIFF
--- a/MT7668-WiFi/7668_firmware/wifi.cfg
+++ b/MT7668-WiFi/7668_firmware/wifi.cfg
@@ -57,10 +57,10 @@ TpTestMode 0
 #SigTaRts 1
 #DynBwRts 1
 EfuseBufferModeCal 1
-RegP2pIfAtProbe 1
+#RegP2pIfAtProbe 1
 Wow 1
 WowEnable 0
-SetChip0 KeepFullPwr 1
+SetChip0 KeepFullPwr 0
 TdlsBufferSTASleep 0
 ChipResetRecover 0
 CalTimingCtrl 1


### PR DESCRIPTION
Commented out RegP2pIfAtProbe (WiFi Direct parameter), causes sporadic boot lockups, and isn't needed. Changed SetChip0 KeepFullPwr to 0, allowing the mt7668 chip to regulate it's power on demand.  Decreases the board power consumption when WiFi isn't in use and when in suspend.